### PR TITLE
[all][templates] fix EditScreenInfo pointing to js file in ts tabs template

### DIFF
--- a/templates/expo-template-tabs/screens/TabOneScreen.tsx
+++ b/templates/expo-template-tabs/screens/TabOneScreen.tsx
@@ -9,7 +9,7 @@ export default function TabOneScreen() {
     <View style={styles.container}>
       <Text style={styles.title}>Tab One</Text>
       <View style={styles.separator} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
-      <EditScreenInfo path="/screens/TabOneScreen.js" />
+      <EditScreenInfo path="/screens/TabOneScreen.tsx" />
     </View>
   );
 }

--- a/templates/expo-template-tabs/screens/TabTwoScreen.tsx
+++ b/templates/expo-template-tabs/screens/TabTwoScreen.tsx
@@ -9,7 +9,7 @@ export default function TabTwoScreen() {
     <View style={styles.container}>
       <Text style={styles.title}>Tab Two</Text>
       <View style={styles.separator} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
-      <EditScreenInfo path="/screens/TabTwoScreen.js" />
+      <EditScreenInfo path="/screens/TabTwoScreen.tsx" />
     </View>
   );
 }


### PR DESCRIPTION
# Why

Typescript tabs template is still displaying EditScreenInfo components prompting the user to edit .js files instead of .tsx files.